### PR TITLE
Implemented proper async execution in ProcessHandler

### DIFF
--- a/src/main/java/com/github/kokorin/jaffree/process/AsyncProcess.java
+++ b/src/main/java/com/github/kokorin/jaffree/process/AsyncProcess.java
@@ -1,0 +1,49 @@
+package com.github.kokorin.jaffree.process;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class AsyncProcess<T> implements Future<T> {
+    private Process process;
+    private Future<T> result;
+
+    public AsyncProcess(Process process, Future<T> result) {
+        this.process = process;
+        this.result = result;
+    }
+
+    public Process getProcess() {
+        return process;
+    }
+
+    public Future<T> getResult() {
+        return result;
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        return result.cancel(mayInterruptIfRunning);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return result.isCancelled();
+    }
+
+    @Override
+    public boolean isDone() {
+        return result.isDone();
+    }
+
+    @Override
+    public T get() throws InterruptedException, ExecutionException {
+        return result.get();
+    }
+
+    @Override
+    public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return result.get(timeout, unit);
+    }
+}

--- a/src/test/java/com/github/kokorin/jaffree/ffmpeg/FFmpegTest.java
+++ b/src/test/java/com/github/kokorin/jaffree/ffmpeg/FFmpegTest.java
@@ -4,6 +4,7 @@ import com.github.kokorin.jaffree.*;
 import com.github.kokorin.jaffree.ffprobe.FFprobe;
 import com.github.kokorin.jaffree.ffprobe.FFprobeResult;
 import com.github.kokorin.jaffree.ffprobe.Stream;
+import com.github.kokorin.jaffree.process.AsyncProcess;
 import org.apache.commons.io.IOUtils;
 import org.junit.*;
 import org.junit.rules.ExpectedException;
@@ -18,7 +19,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -204,7 +204,9 @@ public class FFmpegTest {
                 )
                 .addOutput(UrlOutput.toPath(outputPath));
 
-        Future<FFmpegResult> futureResult = ffmpeg.executeAsync();
+        AsyncProcess<FFmpegResult> futureResult = ffmpeg.executeAsync();
+
+        Assert.assertNotNull(futureResult.getProcess());
 
         Thread.sleep(1_000);
 


### PR DESCRIPTION
The result wraps Future and also provides the executed Process.
Therefore it's backwards compatible with pre-existing code.

Use case: Ability to manage to FFmpeg process, e.g. to suspend it when an encoding job with higher priority is launched.