### PR TITLE
Add User Agent Header Support

### DIFF
--- a/src/main/java/com/github/kokorin/jaffree/ffmpeg/FFmpeg.java
+++ b/src/main/java/com/github/kokorin/jaffree/ffmpeg/FFmpeg.java
@@ -47,6 +47,7 @@ public class FFmpeg {
     private FilterGraph complexFilter;
     // TODO audio and video specific filters: -vf and -af
     private String filter;
+    private String userAgent;
 
     private LogLevel logLevel = null;
     private String contextName = null;
@@ -137,6 +138,11 @@ public class FFmpeg {
         return this;
     }
 
+    public FFmpeg setUserAgent(String userAgent){
+      this.userAgent = userAgent;
+      return this;
+    }
+
     public FFmpegResult execute() {
         List<Runnable> helpers = new ArrayList<>();
 
@@ -206,6 +212,10 @@ public class FFmpeg {
                 throw new RuntimeException("Specified log level " + logLevel + " hides ffmpeg progress output");
             }
             result.addAll(Arrays.asList("-loglevel", Integer.toString(logLevel.code())));
+        }
+
+        if(!userAgent.isEmpty()){
+          result.addAll(Arrays.asList("-user_agent", userAgent));
         }
 
         for (Input input : inputs) {

--- a/src/main/java/com/github/kokorin/jaffree/ffprobe/FFprobe.java
+++ b/src/main/java/com/github/kokorin/jaffree/ffprobe/FFprobe.java
@@ -60,6 +60,7 @@ public class FFprobe {
     private boolean showLibraryVersions;
     private boolean showVersions;
     private boolean showPixelFormats;
+    private String userAgent;
 
     private Long probeSize;
     private Long analyzeDuration;
@@ -431,6 +432,11 @@ public class FFprobe {
         return this;
     }
 
+    public FFprobe setUserAgent(String userAgent){
+      this.userAgent = userAgent;
+      return this;
+    }
+
     public FFprobeResult execute() {
         List<Runnable> helpers = new ArrayList<>();
         if (input != null) {
@@ -452,6 +458,10 @@ public class FFprobe {
 
         if (logLevel != null) {
             result.addAll(Arrays.asList("-loglevel", Integer.toString(logLevel.code())));
+        }
+
+        if(!userAgent.isEmpty()){
+          result.addAll(Arrays.asList("-user_agent", userAgent));
         }
 
         if (selectStreams != null) {


### PR DESCRIPTION
Add user agent header support for ffmpeg & ffprobe. In ffmepg, `-user_agent` arg must come before `-i`, therefor can't use `.addArguments`