### PR TITLE
Fixes issues with HTML-compatibility in Javadoc tags in several source files

### DIFF
--- a/src/main/java/com/github/kokorin/jaffree/LogLevel.java
+++ b/src/main/java/com/github/kokorin/jaffree/LogLevel.java
@@ -18,7 +18,7 @@
 package com.github.kokorin.jaffree;
 
 /**
- * FFmpeg & FFprobe log level.
+ * FFmpeg &amp; FFprobe log level.
  */
 public enum LogLevel {
 

--- a/src/main/java/com/github/kokorin/jaffree/ffmpeg/BaseInOut.java
+++ b/src/main/java/com/github/kokorin/jaffree/ffmpeg/BaseInOut.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Base class which handles common arguments for both ffmpeg input & output.
+ * Base class which handles common arguments for both ffmpeg input &amp; output.
  *
  * @param <T> self
  */
@@ -380,7 +380,7 @@ public abstract class BaseInOut<T extends BaseInOut<T>> {
     }
 
     /**
-     * Build a list of command line arguments that are common for ffmpeg input & output.
+     * Build a list of command line arguments that are common for ffmpeg input &amp; output.
      *
      * @return list of command line arguments
      */

--- a/src/main/java/com/github/kokorin/jaffree/ffmpeg/FFmpeg.java
+++ b/src/main/java/com/github/kokorin/jaffree/ffmpeg/FFmpeg.java
@@ -38,7 +38,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
 
 /**
- * {@link FFmpeg} provides an ability to start & stop ffmpeg process and keep track of
+ * {@link FFmpeg} provides an ability to start &amp; stop ffmpeg process and keep track of
  * encoding progress.
  */
 //TODO add debug statements for all methods

--- a/src/main/java/com/github/kokorin/jaffree/ffmpeg/FFmpegResultFuture.java
+++ b/src/main/java/com/github/kokorin/jaffree/ffmpeg/FFmpegResultFuture.java
@@ -37,7 +37,7 @@ public class FFmpegResultFuture {
     /**
      * Immediately stops ffmpeg process.
      *
-     * <b>Note</b output media may be corrupted.
+     * <b>Note</b> output media may be corrupted.
      */
     public void forceStop() {
         stopper.forceStop();

--- a/src/main/java/com/github/kokorin/jaffree/ffmpeg/FrameInput.java
+++ b/src/main/java/com/github/kokorin/jaffree/ffmpeg/FrameInput.java
@@ -29,7 +29,7 @@ import java.net.Socket;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Allows to supply ffmpeg with audio & video frames constructed in Java.
+ * Allows to supply ffmpeg with audio &amp; video frames constructed in Java.
  *
  * <b>It's strongly recommended</b> to specify {@link #setFrameRate(Number)} for video producing.
  *

--- a/src/main/java/com/github/kokorin/jaffree/ffmpeg/FrameOutput.java
+++ b/src/main/java/com/github/kokorin/jaffree/ffmpeg/FrameOutput.java
@@ -27,7 +27,7 @@ import java.io.InputStream;
 import java.net.Socket;
 
 /**
- * Allows to consume in Java audio & video frames produced by ffmpeg.
+ * Allows to consume in Java audio &amp; video frames produced by ffmpeg.
  */
 public class FrameOutput extends TcpOutput<FrameOutput> implements Output {
     private final FrameOutputNegotiator negotiator;

--- a/src/main/java/com/github/kokorin/jaffree/ffmpeg/NullOutput.java
+++ b/src/main/java/com/github/kokorin/jaffree/ffmpeg/NullOutput.java
@@ -26,7 +26,7 @@ import com.github.kokorin.jaffree.OS;
  * The null muxer uses a wrapped frame so there is no muxing overhead (i.e. it can accept
  * any type of input codec, doesn't have to be rawvideo for instance).
  * <p>
- * Null output can be combined with codec copying to achieve fast & exact file length detection.
+ * Null output can be combined with codec copying to achieve fast &amp; exact file length detection.
  * <p>
  * It may be required also to set {@link FFmpeg#setOverwriteOutput(boolean)} to true.
  *

--- a/src/main/java/com/github/kokorin/jaffree/net/FtpServer.java
+++ b/src/main/java/com/github/kokorin/jaffree/net/FtpServer.java
@@ -37,7 +37,7 @@ import java.nio.channels.SeekableByteChannel;
  * Simple FTP server intended to work <b>only</b> with ffmpeg.
  * <p>
  * This class <b>is not intended to be used as production FTP server</b>
- * since it uses knowledge of how ffmpeg operates with FTP input & output.
+ * since it uses knowledge of how ffmpeg operates with FTP input &amp; output.
  */
 public class FtpServer extends TcpServer {
     private final ServerSocket dataServerSocket;

--- a/src/main/java/com/github/kokorin/jaffree/net/TcpServer.java
+++ b/src/main/java/com/github/kokorin/jaffree/net/TcpServer.java
@@ -32,7 +32,7 @@ import java.net.Socket;
 /**
  * Abstract TCP Server implementing {@link FFHelper}.
  * <p>
- * This class is intended to be used in different ffmpeg {@link Input} & {@link Output}
+ * This class is intended to be used in different ffmpeg {@link Input} &amp; {@link Output}
  * implementations which interact with ffmpeg via TCP sockets.
  */
 public abstract class TcpServer implements FFHelper {

--- a/src/main/java/com/github/kokorin/jaffree/nut/DataItem.java
+++ b/src/main/java/com/github/kokorin/jaffree/nut/DataItem.java
@@ -30,28 +30,28 @@ package com.github.kokorin.jaffree.nut;
  * <p>
  * Types of per frame side data:
  * <uL>
- * <li>"Channels", "ChannelLayout", "SampleRate", "Width", "Height"</li>
+ * <li>"Channels", "ChannelLayout", "SampleRate", "Width", "Height" --
  * This frame changes the number of channels, the channel layout, ... to
  * the given value (ChannelLayout vb, else v)
  * If used in any frame of a stream then every keyframe of the stream
- * SHOULD carry such sidedata to allow seeking.
- * <li>"Extradata", "Palette"</li>
+ * SHOULD carry such sidedata to allow seeking.</li>
+ * <li>"Extradata", "Palette" --
  * This frame changes the codec_specific_data or palette to the given
  * value (vb)
  * If used in any frame of a stream then every keyframe of the stream
- * SHOULD carry such sidedata to allow seeking.
- * <li>"CodecSpecificSide&lt;num&gt;"</li>
+ * SHOULD carry such sidedata to allow seeking.</li>
+ * <li>"CodecSpecificSide&lt;num&gt;" --
  * Codec specific side data, equivalent to matroskas BlockAdditional (vb)
  * the "&lt;num&gt;" should be replaced by a number identifying the type of
- * side data, it is equivalent/equal to BlockAddId in matroska.
- * <li>"SkipStart", "SkipEnd"</li>
+ * side data, it is equivalent/equal to BlockAddId in matroska.</li>
+ * <li>"SkipStart", "SkipEnd" --
  * The decoder should skip/drop the specified number of samples at the
- * start/end of this frame (v)
+ * start/end of this frame (v)</li>
  *
- * <li>"UserData<identifer here>"</li>
+ * <li>"UserData&lt;identifer here&gt;" --
  * User specific side data, the "&lt;identifer here\&gt;" should be replaced
  * by a globally unique identifer of the project that
- * uses/creates/understands the side data. For example "UserDataFFmpeg"
+ * uses/creates/understands the side data. For example "UserDataFFmpeg"</li>
  * </uL>
  * <p>
  * Nut specification references to this data as <b>side/meta data</b> or <b>sm_data</b>

--- a/src/main/java/com/github/kokorin/jaffree/nut/FrameCode.java
+++ b/src/main/java/com/github/kokorin/jaffree/nut/FrameCode.java
@@ -36,7 +36,7 @@ public class FrameCode {
      * frame following this frame_code.
      * <p>
      * If {@link Flag#STREAM_ID} is set then this value has no meaning.
-     * MUST be <250.
+     * MUST be &lt; 250.
      */
     public final int streamId;
 
@@ -113,7 +113,7 @@ public class FrameCode {
      * @param streamId         stream id
      * @param dataSizeMul      data size multiplier
      * @param dataSizeLsb      data size least significant byte
-     * @param ptsDelta         difference between last & current PTS
+     * @param ptsDelta         difference between last &amp; current PTS
      * @param reservedCount    number of reserved bytes
      * @param matchTimeDelta   match time delta
      * @param elisionHeaderIdx index into the elision_header table

--- a/src/main/java/com/github/kokorin/jaffree/nut/package-info.java
+++ b/src/main/java/com/github/kokorin/jaffree/nut/package-info.java
@@ -16,6 +16,6 @@
  */
 
 /**
- * Classes partially implementing NUT container format muxer & demuxer
+ * Classes partially implementing NUT container format muxer &amp; demuxer
  */
 package com.github.kokorin.jaffree.nut;


### PR DESCRIPTION
Now, running mvn javadoc:javadoc no longer results in a failed build.