### PR TITLE
add support for Java 8 completions (promises) API in executeAsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,12 +402,12 @@ See whole examples [here](/src/test/java/examples/CompletionExample.java).
 
 ```java
 ffmpeg.executeAsync().toCompletableFuture()
-        .thenAccept(res -> {
-            // get the result of the operation when it is done
-        })
-        .exceptionally(ex -> {
-            // handle exceptions produced during operation
-        });
+    .thenAccept(res -> {
+        // get the result of the operation when it is done
+    })
+    .exceptionally(ex -> {
+        // handle exceptions produced during operation
+    });
 ```
 
 ## Complex Filtergraph (mosaic video)

--- a/README.md
+++ b/README.md
@@ -396,6 +396,20 @@ Thread.sleep(5_000);
 thread.interrupt();
 ```
 
+## Java 8 Comletion API
+
+See whole examples [here](/src/test/java/examples/CompletionExample.java).
+
+```java
+ffmpeg.executeAsync().toCompletableFuture()
+        .thenAccept(res -> {
+            // get the result of the operation when it is done
+        })
+        .exceptionally(ex -> {
+            // handle exceptions produced during operation
+        });
+```
+
 ## Complex Filtergraph (mosaic video)
 
 More details about this example can be found on ffmpeg wiki:

--- a/src/main/java/com/github/kokorin/jaffree/ffmpeg/FFmpeg.java
+++ b/src/main/java/com/github/kokorin/jaffree/ffmpeg/FFmpeg.java
@@ -366,28 +366,28 @@ public class FFmpeg {
     public FFmpegResultFuture executeAsync() {
         return executeAsync(new Executor() {
             @Override
-            public void execute(Runnable command) {
+            public void execute(final Runnable command) {
                 Thread runner = new Thread(command, "FFmpeg-async-runner");
                 runner.setDaemon(true);
                 runner.start();
             }
         });
     }
-    
+
     /**
-     * Starts asynchronous ffmpeg execution, executed using the supplied Executor
+     * Starts asynchronous ffmpeg execution, executed using the supplied Executor.
      *
      * @param executor the executor to use for asynchronous execution
      * @return ffmpeg result future
      */
-    public FFmpegResultFuture executeAsync(Executor executor) {
+    public FFmpegResultFuture executeAsync(final Executor executor) {
         final ProcessHandler<FFmpegResult> processHandler = createProcessHandler();
         Stopper stopper = createStopper();
         processHandler.setStopper(stopper);
 
         CompletableFuture<FFmpegResult> resultFuture = new CompletableFuture<FFmpegResult>() {
             @Override
-            public boolean cancel(boolean mayInterruptIfRunning) {
+            public boolean cancel(final boolean mayInterruptIfRunning) {
                 if (mayInterruptIfRunning) {
                     stopper.forceStop();
                 } else {

--- a/src/main/java/com/github/kokorin/jaffree/ffmpeg/FFmpeg.java
+++ b/src/main/java/com/github/kokorin/jaffree/ffmpeg/FFmpeg.java
@@ -35,7 +35,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -398,7 +397,7 @@ public class FFmpeg {
             }
         };
 
-        Objects.requireNonNull(executor, "Executor service must be provided").execute(new Runnable() {
+        executor.execute(new Runnable() {
             @Override
             public void run() {
                 try {

--- a/src/main/java/com/github/kokorin/jaffree/ffmpeg/FFmpegResultFuture.java
+++ b/src/main/java/com/github/kokorin/jaffree/ffmpeg/FFmpegResultFuture.java
@@ -17,6 +17,7 @@
 
 package com.github.kokorin.jaffree.ffmpeg;
 
+import com.github.kokorin.jaffree.JaffreeException;
 import com.github.kokorin.jaffree.process.Stopper;
 
 import java.util.concurrent.CancellationException;
@@ -142,7 +143,9 @@ public class FFmpegResultFuture {
     /**
      * Returns a completion that can be used to chain operations after FFmpeg completes, using the
      * {@link CompletionStage} Java 8 API 
-     * @return completion that will complete when 
+     * @return completion that will complete when ffmpeg completes normally, and will complete
+     *  exceptionally with a {@link CancellationException} if ffmpeg is forcefully stopped or with a
+     *  {@link JaffreeException} if an error occurs.
      */
     public CompletableFuture<FFmpegResult> toCompletableFuture() {
         return resultFuture;

--- a/src/main/java/com/github/kokorin/jaffree/ffmpeg/FFmpegResultFuture.java
+++ b/src/main/java/com/github/kokorin/jaffree/ffmpeg/FFmpegResultFuture.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright  2020 Denis Kokorin
+ *    Copyright  2020 Denis Kokorin, Oded Arbel
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,8 +20,9 @@ package com.github.kokorin.jaffree.ffmpeg;
 import com.github.kokorin.jaffree.process.Stopper;
 
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -29,7 +30,7 @@ import java.util.concurrent.TimeoutException;
  * A {@link FFmpegResultFuture} represents the result of an asynchronous ffmpeg execution.
  */
 public class FFmpegResultFuture {
-    private final Future<FFmpegResult> resultFuture;
+    private final CompletableFuture<FFmpegResult> resultFuture;
     private final Stopper stopper;
 
     /**
@@ -38,7 +39,7 @@ public class FFmpegResultFuture {
      * @param resultFuture
      * @param stopper
      */
-    public FFmpegResultFuture(final Future<FFmpegResult> resultFuture, final Stopper stopper) {
+    public FFmpegResultFuture(final CompletableFuture<FFmpegResult> resultFuture, final Stopper stopper) {
         this.resultFuture = resultFuture;
         this.stopper = stopper;
     }
@@ -49,7 +50,7 @@ public class FFmpegResultFuture {
      * <b>Note</b> output media may be corrupted.
      */
     public void forceStop() {
-        stopper.forceStop();
+        resultFuture.cancel(true);
     }
 
     /**
@@ -136,5 +137,14 @@ public class FFmpegResultFuture {
      */
     public boolean isDone() {
         return resultFuture.isDone();
+    }
+    
+    /**
+     * Returns a completion that can be used to chain operations after FFmpeg completes, using the
+     * {@link CompletionStage} Java 8 API 
+     * @return completion that will complete when 
+     */
+    public CompletableFuture<FFmpegResult> toCompletableFuture() {
+        return resultFuture;
     }
 }

--- a/src/main/java/com/github/kokorin/jaffree/ffmpeg/FFmpegResultFuture.java
+++ b/src/main/java/com/github/kokorin/jaffree/ffmpeg/FFmpegResultFuture.java
@@ -40,7 +40,8 @@ public class FFmpegResultFuture {
      * @param resultFuture
      * @param stopper
      */
-    public FFmpegResultFuture(final CompletableFuture<FFmpegResult> resultFuture, final Stopper stopper) {
+    public FFmpegResultFuture(final CompletableFuture<FFmpegResult> resultFuture,
+            final Stopper stopper) {
         this.resultFuture = resultFuture;
         this.stopper = stopper;
     }
@@ -139,10 +140,10 @@ public class FFmpegResultFuture {
     public boolean isDone() {
         return resultFuture.isDone();
     }
-    
+
     /**
      * Returns a completion that can be used to chain operations after FFmpeg completes, using the
-     * {@link CompletionStage} Java 8 API 
+     * {@link CompletionStage} Java 8 API.
      * @return completion that will complete when ffmpeg completes normally, and will complete
      *  exceptionally with a {@link CancellationException} if ffmpeg is forcefully stopped or with a
      *  {@link JaffreeException} if an error occurs.

--- a/src/test/java/examples/CompletionExample.java
+++ b/src/test/java/examples/CompletionExample.java
@@ -1,0 +1,81 @@
+package examples;
+
+import com.github.kokorin.jaffree.ffmpeg.FFmpeg;
+import com.github.kokorin.jaffree.ffmpeg.FFmpegProgress;
+import com.github.kokorin.jaffree.ffmpeg.FFmpegResult;
+import com.github.kokorin.jaffree.ffmpeg.FFmpegResultFuture;
+import com.github.kokorin.jaffree.ffmpeg.NullOutput;
+import com.github.kokorin.jaffree.ffmpeg.ProgressListener;
+import com.github.kokorin.jaffree.ffmpeg.UrlInput;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class CompletionExample {
+    public static void completionWithException(final FFmpeg ffmpeg) throws Exception {
+        final AtomicBoolean stopped = new AtomicBoolean();
+        ffmpeg.setProgressListener(
+                new ProgressListener() {
+                    @Override
+                    public void onProgress(FFmpegProgress progress) {
+                        if (stopped.get()) {
+                            throw new RuntimeException("Stopped with exception!");
+                        }
+                    }
+                }
+        );
+
+        final AtomicReference<FFmpegResult> result = new AtomicReference<>();
+
+        ffmpeg.executeAsync().toCompletableFuture().thenAccept(result::set).exceptionally(ex -> {
+            System.out.println("Completion exception: " + ex);
+            return null;
+        });
+
+        Thread.sleep(5_000);
+        stopped.set(true);
+
+        Thread.sleep(1_000);
+        System.out.println(result.get());
+    }
+
+    public static void completionWithGracefulStop(final FFmpeg ffmpeg) throws Exception {
+        final AtomicReference<FFmpegResult> result = new AtomicReference<>();
+
+        FFmpegResultFuture future = ffmpeg.executeAsync();
+        future.toCompletableFuture().thenAccept(result::set);
+
+        Thread.sleep(5_000);
+        future.graceStop();
+
+        Thread.sleep(1_000);
+        System.out.println(result.get());
+    }
+
+    public static void main(String[] args) throws Exception {
+        FFmpeg ffmpeg;
+        ffmpeg = createTestFFmpeg();
+        completionWithException(ffmpeg);
+
+        ffmpeg = createTestFFmpeg();
+        completionWithGracefulStop(ffmpeg);
+    }
+
+    public static FFmpeg createTestFFmpeg() {
+        return FFmpeg.atPath()
+                .addInput(
+                        UrlInput
+                                .fromUrl("testsrc=duration=3600:size=1280x720:rate=30")
+                                .setFormat("lavfi")
+                )
+                .setProgressListener(new ProgressListener() {
+                    @Override
+                    public void onProgress(FFmpegProgress progress) {
+                        //System.out.println(progress);
+                    }
+                })
+                .addOutput(
+                        new NullOutput()
+                );
+    }
+}


### PR DESCRIPTION
[Re-posting of PR #166]

With the unfortunate state of Java `Future` and `FutureTask` - an API introduced in Java 5, before the explosion in popularity of the "promise"-style APIs - that is used in `FFmpeg.executeAsync()`, it is not possible to wait for an asynchronous task completion without blocking a thread.

With Java 8's introduction of the `CompletionStage` interface and `CompletableFuture` implementation, this has changed and allows a simpler way to wait for completion without blocking, that maps well to established asynchronous and reactive programming patterns.

This PR adds into `FFmpegResultFuture` support for producing a `CompletableFuture` instance so that additional actions can be chained to the processing result without blocking an additional thread. Chained actions are called in the context of the `executeAsync()`'s internal runner thread, right before it terminates, so the additional behavior should not cause any scheduling conflict or increased latency (other than expected).