### PR TITLE
Issue 195: index out of bounds in NutReader

### DIFF
--- a/src/main/java/com/github/kokorin/jaffree/nut/NutReader.java
+++ b/src/main/java/com/github/kokorin/jaffree/nut/NutReader.java
@@ -1,5 +1,6 @@
 /*
  *    Copyright  2017 Denis Kokorin
+ *    Copyright  2021 Mark Lassau
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/kokorin/jaffree/nut/NutReader.java
+++ b/src/main/java/com/github/kokorin/jaffree/nut/NutReader.java
@@ -1,6 +1,5 @@
 /*
- *    Copyright  2017 Denis Kokorin
- *    Copyright  2021 Mark Lassau
+ *    Copyright 2017-2021 Denis Kokorin, Mark Lassau
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/kokorin/jaffree/nut/NutReader.java
+++ b/src/main/java/com/github/kokorin/jaffree/nut/NutReader.java
@@ -122,8 +122,9 @@ public class NutReader {
                 SyncPoint syncPoint = readSyncPoint();
                 long pts = syncPoint.globalKeyPts.pts;
                 Rational ptsTimebase = mainHeader.timeBases[syncPoint.globalKeyPts.timebaseId];
-                for (int i = 0; i < mainHeader.timeBases.length; i++) {
-                    lastPts[i] = Util.convertTimestamp(pts, ptsTimebase, mainHeader.timeBases[i]);
+                for (int i = 0; i < mainHeader.streamCount; i++) {
+                    Rational streamTimeBase = mainHeader.timeBases[streamHeaders[i].timeBaseId];
+                    lastPts[i] = Util.convertTimestamp(pts, ptsTimebase, streamTimeBase);
                 }
             }
 

--- a/src/test/java/com/github/kokorin/jaffree/Artifacts.java
+++ b/src/test/java/com/github/kokorin/jaffree/Artifacts.java
@@ -26,6 +26,7 @@ public class Artifacts {
     public static final Path AUDIO_OPUS = getOpusArtifact(180);
     public static final Path VIDEO_MJPEG = getMjpegArtifact(20);
     public static final Path VIDEO_NUT = getNutArtifact(180);
+    public static final Path VIDEO_NUT_WITH_CHAPTERS = getNutArtifactWithChapters();
 
     private static Path getMp4Artifact(int duration) {
         return getArtifact("640x480", 30, 44_100, "mp4", duration);
@@ -38,6 +39,24 @@ public class Artifacts {
     private static synchronized Path getNutArtifact(int duration) {
         Path source = getMp4Artifact(duration);
         String filename = source.getFileName().toString().replace(".mp4", ".nut");
+        Path result = getSamplePath(filename);
+
+        if (!Files.exists(result)) {
+            FFmpeg.atPath()
+                    .addInput(UrlInput.fromPath(source))
+                    .addOutput(UrlOutput
+                            .toPath(result)
+                            .copyAllCodecs()
+                    )
+                    .execute();
+        }
+
+        return result;
+    }
+
+    private static synchronized Path getNutArtifactWithChapters() {
+        Path source = getMkvArtifactWithChapters();
+        String filename = source.getFileName().toString().replace(".mkv", ".nut");
         Path result = getSamplePath(filename);
 
         if (!Files.exists(result)) {

--- a/src/test/java/com/github/kokorin/jaffree/nut/NutReaderTest.java
+++ b/src/test/java/com/github/kokorin/jaffree/nut/NutReaderTest.java
@@ -1,0 +1,29 @@
+package com.github.kokorin.jaffree.nut;
+
+import com.github.kokorin.jaffree.Artifacts;
+import org.junit.Test;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertEquals;
+
+public class NutReaderTest {
+
+    /**
+     * Asserts a bugfix for ArrayIndexOutOfBoundsException in NutReader.
+     * This would previously happen when the streamCount was smaller than the timebase count.
+     * See https://github.com/kokorin/Jaffree/issues/195 for original bug report.
+     */
+    @Test
+    public void testGetMainHeaderWithExtraTimebase() throws IOException {
+        InputStream inputStream = new FileInputStream(Artifacts.VIDEO_NUT_WITH_CHAPTERS.toFile());
+        NutReader nutReader = new NutReader(new NutInputStream(inputStream));
+
+        // this would previously throw ArrayIndexOutOfBoundsException
+        MainHeader mainHeader = nutReader.getMainHeader();
+        assertEquals(2, mainHeader.streamCount);
+        assertEquals(3, mainHeader.timeBases.length);
+    }
+}


### PR DESCRIPTION
Proposed fix for ArrayIndexOutOfBoundsException at NutReader.readToFrame(NutReader.java:126)