### PR TITLE
Change the input parameter generic of FilterChain#addFilters

### DIFF
--- a/src/main/java/com/github/kokorin/jaffree/ffmpeg/FilterChain.java
+++ b/src/main/java/com/github/kokorin/jaffree/ffmpeg/FilterChain.java
@@ -48,7 +48,7 @@ public class FilterChain {
      * @param filtersToAdd filters to add
      * @return this
      */
-    public FilterChain addFilters(final List<Filter> filtersToAdd) {
+    public FilterChain addFilters(final List<? extends Filter> filtersToAdd) {
         filters.addAll(filtersToAdd);
         return this;
     }

--- a/src/main/java/com/github/kokorin/jaffree/ffmpeg/FilterGraph.java
+++ b/src/main/java/com/github/kokorin/jaffree/ffmpeg/FilterGraph.java
@@ -48,7 +48,7 @@ public class FilterGraph {
      * @param chainsToAdd filter chains to add
      * @return this
      */
-    public FilterGraph addFilterChains(final List<FilterChain> chainsToAdd) {
+    public FilterGraph addFilterChains(final List<? extends FilterChain> chainsToAdd) {
         chains.addAll(chainsToAdd);
         return this;
     }


### PR DESCRIPTION
```java
List<GenericFilter> list = new ArrayList<>();
list.add(...);
// A cast is required here
new FilterChain().addFilters((List) list);
```

Using generic caps is a good way to handle this situation