### PR TITLE
Fixes for recent FFmpeg versions

### DIFF
--- a/src/main/java/com/github/kokorin/jaffree/util/ParseUtil.java
+++ b/src/main/java/com/github/kokorin/jaffree/util/ParseUtil.java
@@ -24,14 +24,15 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Parses ffmpeg progress and result values.
  */
 @SuppressWarnings("checkstyle:MagicNumber")
 public final class ParseUtil {
-
-    private static final String KBYTES_SUFFIX = "kB";
+    private static final Pattern KBYTES_SUFFIX_PATTERN = Pattern.compile("\\d+(KiB|kB)");
     private static final String KBITS_PER_SECOND_SUFFIX = "kbits/s";
     private static final String SPEED_SUFFIX = "x";
     private static final String PERCENT_SUFFIX = "%";
@@ -104,7 +105,9 @@ public final class ParseUtil {
             return null;
         }
 
-        return parseLongWithSuffix(value.trim(), KBYTES_SUFFIX);
+        final Matcher matcher = KBYTES_SUFFIX_PATTERN.matcher(value);
+
+        return matcher.find() ? parseLongWithSuffix(value.trim(), matcher.group(1)) : null;
     }
 
     /**

--- a/src/main/java/com/github/kokorin/jaffree/util/ParseUtil.java
+++ b/src/main/java/com/github/kokorin/jaffree/util/ParseUtil.java
@@ -77,28 +77,28 @@ public final class ParseUtil {
     }
 
     /**
-     * Parses size in kilobytes without exception.
+     * Parses size in kibibytes without exception.
      *
      * @param value string to parse
      * @return parsed long or null if value can't be parsed
      */
     public static Long parseSizeInBytes(final String value) {
-        Long result = parseSizeInKiloBytes(value);
+        Long result = parseSizeInKibiBytes(value);
 
         if (result == null) {
             return null;
         }
 
-        return result * 1000;
+        return result * 1024;
     }
 
     /**
-     * Parses size in kilobytes without exception.
+     * Parses size in kibibytes without exception.
      *
      * @param value string to parse
      * @return parsed long or null if value can't be parsed
      */
-    public static Long parseSizeInKiloBytes(final String value) {
+    public static Long parseSizeInKibiBytes(final String value) {
         if (value == null || value.isEmpty()) {
             return null;
         }

--- a/src/main/java/com/github/kokorin/jaffree/util/ParseUtil.java
+++ b/src/main/java/com/github/kokorin/jaffree/util/ParseUtil.java
@@ -105,9 +105,10 @@ public final class ParseUtil {
             return null;
         }
 
-        final Matcher matcher = KBYTES_SUFFIX_PATTERN.matcher(value);
+        final String trimmedValue = value.trim();
+        final Matcher matcher = KBYTES_SUFFIX_PATTERN.matcher(trimmedValue);
 
-        return matcher.find() ? parseLongWithSuffix(value.trim(), matcher.group(1)) : null;
+        return matcher.find() ? parseLongWithSuffix(trimmedValue, matcher.group(1)) : null;
     }
 
     /**

--- a/src/main/java/com/github/kokorin/jaffree/util/ParseUtil.java
+++ b/src/main/java/com/github/kokorin/jaffree/util/ParseUtil.java
@@ -24,15 +24,13 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Parses ffmpeg progress and result values.
  */
 @SuppressWarnings("checkstyle:MagicNumber")
 public final class ParseUtil {
-    private static final Pattern KBYTES_SUFFIX_PATTERN = Pattern.compile("\\d+(KiB|kB)");
+    private static final String[] KBYTES_SUFFIXES = {"kB", "KiB"};
     private static final String KBITS_PER_SECOND_SUFFIX = "kbits/s";
     private static final String SPEED_SUFFIX = "x";
     private static final String PERCENT_SUFFIX = "%";
@@ -106,9 +104,13 @@ public final class ParseUtil {
         }
 
         final String trimmedValue = value.trim();
-        final Matcher matcher = KBYTES_SUFFIX_PATTERN.matcher(trimmedValue);
+        Long result = null;
 
-        return matcher.find() ? parseLongWithSuffix(trimmedValue, matcher.group(1)) : null;
+        for (int i = 0; i < KBYTES_SUFFIXES.length && result == null; i++) {
+            result = parseLongWithSuffix(trimmedValue, KBYTES_SUFFIXES[i]);
+        }
+
+        return result;
     }
 
     /**

--- a/src/test/java/com/github/kokorin/jaffree/ffmpeg/FFmpegTest.java
+++ b/src/test/java/com/github/kokorin/jaffree/ffmpeg/FFmpegTest.java
@@ -242,6 +242,29 @@ public class FFmpegTest {
     }
 
     @Test
+    public void testFrameCountingWithStreamCopyAndProgressListener() throws Exception {
+        final AtomicReference<Long> frameRef = new AtomicReference<>();
+
+        final ProgressListener progressListener = new ProgressListener() {
+            @Override
+            public void onProgress(FFmpegProgress progress) {
+                System.out.println(progress);
+                frameRef.set(progress.getFrame());
+            }
+        };
+
+        final FFmpegResult result = FFmpeg.atPath(Config.FFMPEG_BIN)
+                .addInput(UrlInput.fromPath(Artifacts.VIDEO_NUT))
+                .addOutput(new NullOutput())
+                .setProgressListener(progressListener)
+                .execute();
+
+        // Note fails in FFmpeg 6.1, 6.1.1, 6.1.2, 7.0, 7.0.1, 7.0.2. To be fixed in the next release, see:
+        // https://github.com/FFmpeg/FFmpeg/commit/598f541ba49cb682dcd74e86858c9a4985149e1f
+        assertNotNull(frameRef.get());
+    }
+
+    @Test
     public void testForceStopWithThreadInterruption() throws Exception {
         Path tempDir = Files.createTempDirectory("jaffree");
         Path outputPath = tempDir.resolve(Artifacts.VIDEO_MP4.getFileName());

--- a/src/test/java/com/github/kokorin/jaffree/ffmpeg/FFmpegTest.java
+++ b/src/test/java/com/github/kokorin/jaffree/ffmpeg/FFmpegTest.java
@@ -43,6 +43,7 @@ import static java.nio.file.StandardOpenOption.WRITE;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -519,14 +520,20 @@ public class FFmpegTest {
                 .addOutput(new NullOutput())
                 .execute();
         } catch (JaffreeAbnormalExitException e) {
-            assertEquals("Process execution has ended with non-zero status: 1. Check logs for detailed error message.", e.getMessage());
-            assertEquals(1, e.getProcessErrorLogMessages().size());
-            assertEquals("[error] non_existent.mp4: No such file or directory", e.getProcessErrorLogMessages().get(0).message);
+            if ("Process execution has ended with non-zero status: 254. Check logs for detailed error message.".equals(e.getMessage())) {
+                // FFmpeg 6+
+                assertEquals(3, e.getProcessErrorLogMessages().size());
+                assertEquals("[error] Error opening input file non_existent.mp4.", e.getProcessErrorLogMessages().get(1).message);
+            } else if ("Process execution has ended with non-zero status: 1. Check logs for detailed error message.".equals(e.getMessage())) {
+                assertEquals(1, e.getProcessErrorLogMessages().size());
+                assertEquals("[error] non_existent.mp4: No such file or directory", e.getProcessErrorLogMessages().get(0).message);
+            } else {
+                fail("Unknown FFmpeg output format (update test code!)");
+            }
             return;
         }
 
         fail("JaffreeAbnormalExitException should have been thrown!");
-
     }
 
     @Test

--- a/src/test/java/com/github/kokorin/jaffree/ffmpeg/FFmpegTest.java
+++ b/src/test/java/com/github/kokorin/jaffree/ffmpeg/FFmpegTest.java
@@ -259,7 +259,7 @@ public class FFmpegTest {
                 .setProgressListener(progressListener)
                 .execute();
 
-        // Note fails in FFmpeg 6.1, 6.1.1, 6.1.2, 7.0, 7.0.1, 7.0.2. To be fixed in the next release, see:
+        // Fails in FFmpeg 6.1, 6.1.1, 6.1.2, 7.0, 7.0.1, 7.0.2. To be fixed in the next release, see:
         // https://github.com/FFmpeg/FFmpeg/commit/598f541ba49cb682dcd74e86858c9a4985149e1f
         assertNotNull(frameRef.get());
     }

--- a/src/test/java/com/github/kokorin/jaffree/util/ParseUtilTest.java
+++ b/src/test/java/com/github/kokorin/jaffree/util/ParseUtilTest.java
@@ -63,13 +63,25 @@ public class ParseUtilTest {
     }
 
     @Test
-    public void parsResult() throws Exception {
+    public void parseOldKibiByteFormats() {
+        final Long value = ParseUtil.parseSizeInKibiBytes("2904kB");
+        Assert.assertEquals(2904L, value.longValue());
+    }
+
+    @Test
+    public void parseNewKibiByteFormats() {
+        final Long value = ParseUtil.parseSizeInKibiBytes("2904KiB");
+        Assert.assertEquals(2904L, value.longValue());
+    }
+
+    @Test
+    public void parseResult() throws Exception {
         String value = "video:1417kB audio:113kB subtitle:0kB other streams:0kB global headers:0kB muxing overhead: unknown";
         FFmpegResult result = ParseUtil.parseResult(value);
 
         Assert.assertNotNull(result);
-        Assert.assertEquals((Long) 1_417_000L, result.getVideoSize());
-        Assert.assertEquals((Long) 113_000L, result.getAudioSize());
+        Assert.assertEquals((Long) 1_451_008L, result.getVideoSize());
+        Assert.assertEquals((Long) 115_712L, result.getAudioSize());
         Assert.assertEquals((Long) 0L, result.getSubtitleSize());
         Assert.assertEquals((Long) 0L, result.getOtherStreamsSize());
         Assert.assertEquals((Long) 0L, result.getGlobalHeadersSize());
@@ -98,5 +110,4 @@ public class ParseUtilTest {
 
         Assert.assertNull(result);
     }
-
 }

--- a/src/test/java/com/github/kokorin/jaffree/util/ParseUtilTest.java
+++ b/src/test/java/com/github/kokorin/jaffree/util/ParseUtilTest.java
@@ -69,6 +69,9 @@ public class ParseUtilTest {
 
         final Long newFormat = ParseUtil.parseSizeInKibiBytes("2904KiB");
         Assert.assertEquals(2904L, newFormat.longValue());
+
+        final Long unknownFormat = ParseUtil.parseSizeInKibiBytes("2904KB");
+        Assert.assertNull(unknownFormat);
     }
 
     @Test

--- a/src/test/java/com/github/kokorin/jaffree/util/ParseUtilTest.java
+++ b/src/test/java/com/github/kokorin/jaffree/util/ParseUtilTest.java
@@ -63,15 +63,12 @@ public class ParseUtilTest {
     }
 
     @Test
-    public void parseOldKibiByteFormats() {
-        final Long value = ParseUtil.parseSizeInKibiBytes("2904kB");
-        Assert.assertEquals(2904L, value.longValue());
-    }
+    public void parseKibiByteFormats() {
+        final Long oldFormat = ParseUtil.parseSizeInKibiBytes("2904kB");
+        Assert.assertEquals(2904L, oldFormat.longValue());
 
-    @Test
-    public void parseNewKibiByteFormats() {
-        final Long value = ParseUtil.parseSizeInKibiBytes("2904KiB");
-        Assert.assertEquals(2904L, value.longValue());
+        final Long newFormat = ParseUtil.parseSizeInKibiBytes("2904KiB");
+        Assert.assertEquals(2904L, newFormat.longValue());
     }
 
     @Test


### PR DESCRIPTION
1. Fixes an issue with parsing the kilobyte unit (`KiB`) in newer FFmpeg versions.
2. Fixed the `testExceptionIsThrownIfFfmpegExitsWithError` unit test (again, because the output has recently changed).
3. I noticed a regression in my own software and added `testFrameCountingWithStreamCopyAndProgressListener` to test frame counting while performing a stream copy. It runs as expected on older FFmpeg versions but fails with recent versions (6.1.x and 7.0.x) due to a bug (which was fixed a week ago on their master branch).