### PR TITLE
Process Listener API

### DIFF
--- a/src/main/java/com/github/kokorin/jaffree/ffmpeg/FFmpeg.java
+++ b/src/main/java/com/github/kokorin/jaffree/ffmpeg/FFmpeg.java
@@ -23,6 +23,7 @@ import com.github.kokorin.jaffree.net.NegotiatingTcpServer;
 import com.github.kokorin.jaffree.process.LoggingStdReader;
 import com.github.kokorin.jaffree.process.ProcessHandler;
 import com.github.kokorin.jaffree.process.ProcessHelper;
+import com.github.kokorin.jaffree.process.ProcessListener;
 import com.github.kokorin.jaffree.process.StdReader;
 import com.github.kokorin.jaffree.process.Stopper;
 import org.slf4j.Logger;
@@ -50,6 +51,7 @@ public class FFmpeg {
     private boolean overwriteOutput;
     private ProgressListener progressListener;
     private OutputListener outputListener;
+    private ProcessListener processListener;
     private String progress;
     //-filter_threads nb_threads (global)
     //-debug_ts (global)
@@ -345,6 +347,17 @@ public class FFmpeg {
     }
 
     /**
+     * Supply a ProcessListener to receive access to the Active Process instance of FFmpeg.
+     * <p>
+     * Providing you self control on how the processes are kept alive or tracked.
+     * Since the commandline doesn't guarantee to listen to shutdown commands.
+     */
+    public FFmpeg setProcessListener(final ProcessListener processListener) {
+        this.processListener = processListener;
+        return this;
+    }
+
+    /**
      * Send program-friendly progress information to url.
      * <p>
      * Progress information is written periodically and at the end of the encoding process. It is
@@ -506,6 +519,7 @@ public class FFmpeg {
                         .setStdErrReader(createStdErrReader(outputListener))
                         .setStdOutReader(createStdOutReader())
                         .setHelpers(helpers)
+                        .setProcessListener(processListener)
                         .setArguments(buildArguments());
         if (executorTimeoutMillis != null) {
             processHandler.setExecutorTimeoutMillis(executorTimeoutMillis);

--- a/src/main/java/com/github/kokorin/jaffree/ffprobe/FFprobe.java
+++ b/src/main/java/com/github/kokorin/jaffree/ffprobe/FFprobe.java
@@ -22,6 +22,7 @@ import com.github.kokorin.jaffree.StreamType;
 import com.github.kokorin.jaffree.ffprobe.data.FormatParser;
 import com.github.kokorin.jaffree.ffprobe.data.JsonFormatParser;
 import com.github.kokorin.jaffree.process.ProcessHandler;
+import com.github.kokorin.jaffree.process.ProcessListener;
 import com.github.kokorin.jaffree.process.ProcessHelper;
 import com.github.kokorin.jaffree.process.StdReader;
 
@@ -68,6 +69,7 @@ public class FFprobe {
     private String format;
     private Input input;
 
+    private ProcessListener processListener;
     private FormatParser formatParser = new JsonFormatParser();
 
     private final Path executable;
@@ -473,6 +475,17 @@ public class FFprobe {
     }
 
     /**
+     * Supply a ProcessListener to receive access to the Active Process instance of FFprobe.
+     * <p>
+     * Providing you self control on how the processes are kept alive or tracked.
+     * Since the commandline doesn't guarantee to listen to shutdown commands.
+     */
+    public FFprobe setProcessListener(final ProcessListener processListener) {
+        this.processListener = processListener;
+        return this;
+    }
+
+    /**
      * Sets ffprobe output format parser (and corresponding output format).
      * <p>
      * {@link JsonFormatParser} is used by default. It's possible to provide custom implementation.
@@ -545,6 +558,7 @@ public class FFprobe {
                 .setStdOutReader(createStdOutReader(formatParser))
                 .setStdErrReader(createStdErrReader())
                 .setHelpers(helpers)
+                .setProcessListener(processListener)
                 .setArguments(buildArguments())
                 .execute();
     }

--- a/src/main/java/com/github/kokorin/jaffree/process/ProcessListener.java
+++ b/src/main/java/com/github/kokorin/jaffree/process/ProcessListener.java
@@ -1,0 +1,18 @@
+package com.github.kokorin.jaffree.process;
+
+/**
+ * @Author Speiger
+ */
+public class ProcessListener {
+
+    /**
+     * Callback for when the Process is started.
+     * @param process the started process
+     */
+    public void onProcessStart(Process process);
+    /**
+     * Callback for when the Process is stopped for whatever reason.
+     * @param process the stopped process
+     */
+    public void onProcessStop(Process process);
+}


### PR DESCRIPTION
Creates a Listener API for Process instances done by this library. That way giving library users more control over how processes are stopped.

The Stopper API itself never guarantees that the Processes are stopped and this assures that the guarantee can be self implemented.

Edit: This should solve #383 